### PR TITLE
1.12.2におけるIFTTTブロックのクラッシュ修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,18 +5,22 @@ buildscript {
 			name = "forge"
 			url = "https://maven.minecraftforge.net/"
 		}
+		gradlePluginPortal()
+        jcenter()
 	}
 	dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:4.+'
     }
 }
 
-configurations {
-    embed
-    compile.extendsFrom(embed)
+plugins {
+    // this version works on gradle 4.9
+    // more recent versions of shadow work on more recent versions of gradle
+    id 'com.github.johnrengelman.shadow' version '4.0.4'
 }
 
 apply plugin: 'net.minecraftforge.gradle'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 version = "1.12.2-SNAPSHOT"
 group = "jp.kaiz.atsassistmod" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
@@ -97,21 +101,31 @@ dependencies {
     implementation "curse.maven:ngtlib-288989:3003745"
     implementation "curse.maven:realtrainmod-288988:3061973"
 
-    embed 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-    embed 'com.fasterxml.jackson.core:jackson-core:2.15.2'
-    embed 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
-    embed 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2'
 }
 
-jar {
-    configurations.embed.each { dep ->
-        from(project.zipTree(dep)) {
-            exclude 'META-INF', 'META-INF/versions/**', 'META-INF/maven/**', '**/module-info.class'
-        }
+shadowJar {
+    archiveClassifier.set('')
+
+    // Include ONLY jackson
+    dependencies {
+        include(dependency('com.fasterxml.jackson.core:.*'))
+        include(dependency('com.fasterxml.jackson.dataformat:.*'))
     }
 
-    from(rootDir) {
-        include 'README.md'
-        include 'LICENCE'
-    }
+    // Relocate jackson packages
+    relocate 'com.fasterxml.jackson', 'jp.kaiz.atsassistmod.shadow.jackson'
+
+    // Safety exclusions
+    exclude 'META-INF/**'
+    exclude '**/module-info.class'
 }
+
+reobf {
+    shadowJar { }
+}
+
+tasks.build.dependsOn tasks.shadowJar

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,6 @@ buildscript {
 			name = "forge"
 			url = "https://maven.minecraftforge.net/"
 		}
-		gradlePluginPortal()
-        jcenter()
 	}
 	dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:4.+'

--- a/build.gradle
+++ b/build.gradle
@@ -97,13 +97,16 @@ dependencies {
     implementation "curse.maven:ngtlib-288989:3003745"
     implementation "curse.maven:realtrainmod-288988:3061973"
 
+    embed 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    embed 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+    embed 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
     embed 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2'
 }
 
 jar {
     configurations.embed.each { dep ->
         from(project.zipTree(dep)) {
-            exclude 'META-INF', 'META-INF/versions/**', 'META-INF/maven/**'
+            exclude 'META-INF', 'META-INF/versions/**', 'META-INF/maven/**', '**/module-info.class'
         }
     }
 

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -14,7 +14,7 @@
     "logoFile": "",
     "screenshots": [],
     "dependencies": [
-      "RTM"
+      "rtm"
     ]
   }
 ]


### PR DESCRIPTION
### 概要
#68 で発生していた依存関係の競合を修正しました。

### 変更内容
- shadowJar の設定: 実行可能な Fat JAR を生成するために shadowJar タスクを導入しました。

- Jackson のリロケート: 他のライブラリが使用する Jackson とのバージョン競合を避けるため、パッケージをリロケート（再配置）するように設定しました。

### 備考
これにより、IFTTT保存時に発生していた NoClassDefFoundErrorが解消されることを確認済みです。