### PR TITLE
1.12.2：特定環境でIF/THENの保存内容が反映されない不具合の修正(`IFTTTUtil`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,38 +1,9 @@
-# eclipse
-bin
-*.launch
-.settings
-.metadata
-.classpath
-.project
+/.gradle/
+/.idea/
+/build/
+/classes/
+/eclipse/
 
-# idea
-out
+*.iml
 *.ipr
 *.iws
-*.iml
-.idea
-
-# gradle
-build
-.gradle
-
-# other
-eclipse
-run
-
-# Files from Forge MDK
-forge*changelog.txt
-.gitattributes
-# macOS system files
-.DS_Store
-# Applepie
-# 追記:AppleExtendedから適当にコピペしたので下のやつ気にしないでください。
-libs/
-/src/main/resources/_COROUTINE/
-/src/main/resources/com/
-/src/main/resources/io/
-/src/main/resources/kotlin/
-/src/main/resources/kotlinx/
-/src/main/resources/org/
-/src/main/resources/assets/fix-rtm/

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ forge*changelog.txt
 # macOS system files
 .DS_Store
 # Applepie
+# 追記:AppleExtendedから適当にコピペしたので下のやつ気にしないでください。
 libs/
 /src/main/resources/_COROUTINE/
 /src/main/resources/com/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# eclipse
+bin
+*.launch
+.settings
+.metadata
+.classpath
+.project
+
+# idea
+out
+*.ipr
+*.iws
+*.iml
+.idea
+
+# gradle
+build
+.gradle
+
+# other
+eclipse
+run
+
+# Files from Forge MDK
+forge*changelog.txt
+.gitattributes
+# macOS system files
+.DS_Store
+# Applepie
+libs/
+/src/main/resources/_COROUTINE/
+/src/main/resources/com/
+/src/main/resources/io/
+/src/main/resources/kotlin/
+/src/main/resources/kotlinx/
+/src/main/resources/org/
+/src/main/resources/assets/fix-rtm/

--- a/src/main/java/jp/kaiz/atsassistmod/ifttt/IFTTTUtil.java
+++ b/src/main/java/jp/kaiz/atsassistmod/ifttt/IFTTTUtil.java
@@ -1,6 +1,9 @@
 package jp.kaiz.atsassistmod.ifttt;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -13,11 +16,19 @@ import java.util.stream.Collectors;
 
 public class IFTTTUtil {
     private final static Gson GSON = new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
+    private static final ObjectMapper IFTTT_MAPPER = createIFTTTMapper();
+
+    private static ObjectMapper createIFTTTMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
 
     public static byte[] convertClassSafe(IFTTTContainer ifcb) {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.writeValueAsBytes(ifcb);
+            return IFTTT_MAPPER.writeValueAsBytes(ifcb);
         } catch (JsonProcessingException e) {
             e.printStackTrace();
         }
@@ -26,8 +37,7 @@ public class IFTTTUtil {
 
     public static IFTTTContainer convertClassSafe(byte[] bytes) {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(bytes, IFTTTContainer.class);
+            return IFTTT_MAPPER.readValue(bytes, IFTTTContainer.class);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/jp/kaiz/atsassistmod/ifttt/IFTTTUtil.java
+++ b/src/main/java/jp/kaiz/atsassistmod/ifttt/IFTTTUtil.java
@@ -16,9 +16,12 @@ public class IFTTTUtil {
 
     public static byte[] convertClassSafe(IFTTTContainer ifcb) {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.writeValueAsBytes(ifcb);
-        } catch (JsonProcessingException e) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(ifcb);
+            oos.flush();
+            return baos.toByteArray();
+        } catch (IOException e) {
             e.printStackTrace();
         }
         return null;
@@ -26,9 +29,9 @@ public class IFTTTUtil {
 
     public static IFTTTContainer convertClassSafe(byte[] bytes) {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(bytes, IFTTTContainer.class);
-        } catch (IOException e) {
+            ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes));
+            return (IFTTTContainer) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
             e.printStackTrace();
         }
         return null;

--- a/src/main/java/jp/kaiz/atsassistmod/ifttt/IFTTTUtil.java
+++ b/src/main/java/jp/kaiz/atsassistmod/ifttt/IFTTTUtil.java
@@ -1,30 +1,34 @@
 package jp.kaiz.atsassistmod.ifttt;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 public class IFTTTUtil {
     private final static Gson GSON = new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
+    private static final ObjectMapper IFTTT_MAPPER = createIFTTTMapper();
+
+    private static ObjectMapper createIFTTTMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
 
     public static byte[] convertClassSafe(IFTTTContainer ifcb) {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.writeValueAsBytes(ifcb);
+            return IFTTT_MAPPER.writeValueAsBytes(ifcb);
         } catch (JsonProcessingException e) {
             e.printStackTrace();
         }
@@ -32,85 +36,12 @@ public class IFTTTUtil {
     }
 
     public static IFTTTContainer convertClassSafe(byte[] bytes) {
-        ObjectMapper objectMapper = new ObjectMapper();
         try {
-            return objectMapper.readValue(bytes, IFTTTContainer.class);
+            return IFTTT_MAPPER.readValue(bytes, IFTTTContainer.class);
         } catch (IOException e) {
-            debugDeserializeFailure(objectMapper, bytes, e);
             e.printStackTrace();
         }
         return null;
-    }
-
-    private static void debugDeserializeFailure(ObjectMapper objectMapper, byte[] bytes, IOException exception) {
-        System.out.println("[ATSAssist][IFTTT-DEBUG] deserialize failed: " + exception.getClass().getName() + " / " + exception.getMessage());
-        if (exception instanceof JsonMappingException) {
-            JsonMappingException jsonMappingException = (JsonMappingException) exception;
-            System.out.println("[ATSAssist][IFTTT-DEBUG] path: " + jsonMappingException.getPathReference());
-        }
-        System.out.println("[ATSAssist][IFTTT-DEBUG] payload bytes: " + (bytes == null ? "null" : bytes.length));
-        if (bytes == null) {
-            return;
-        }
-
-        try {
-            String json = new String(bytes, StandardCharsets.UTF_8);
-            System.out.println("[ATSAssist][IFTTT-DEBUG] payload json: " + json);
-            JsonNode root = objectMapper.readTree(bytes);
-            if (root != null && root.has("@class")) {
-                String className = root.get("@class").asText();
-                System.out.println("[ATSAssist][IFTTT-DEBUG] @class: " + className);
-                try {
-                    Class<?> targetClass = Class.forName(className);
-                    debugClassInfo(objectMapper, targetClass);
-                } catch (ClassNotFoundException classNotFoundException) {
-                    System.out.println("[ATSAssist][IFTTT-DEBUG] @class not found: " + classNotFoundException.getMessage());
-                }
-            }
-        } catch (IOException parseException) {
-            System.out.println("[ATSAssist][IFTTT-DEBUG] could not parse payload as json: " + parseException.getMessage());
-        }
-
-        debugClassInfo(objectMapper, IFTTTContainer.class);
-    }
-
-    private static void debugClassInfo(ObjectMapper objectMapper, Class<?> clazz) {
-        try {
-            JavaType javaType = objectMapper.getTypeFactory().constructType(clazz);
-            AtomicReference<Throwable> cause = new AtomicReference<>();
-            boolean canDeserialize = objectMapper.canDeserialize(javaType, cause);
-            System.out.println("[ATSAssist][IFTTT-DEBUG] canDeserialize " + clazz.getName() + ": " + canDeserialize);
-            if (cause.get() != null) {
-                System.out.println("[ATSAssist][IFTTT-DEBUG] canDeserialize cause for " + clazz.getName() + ":");
-                cause.get().printStackTrace();
-            }
-
-            BeanDescription description = objectMapper.getDeserializationConfig().introspect(javaType);
-            for (BeanPropertyDefinition property : description.findProperties()) {
-                String typeName;
-                try {
-                    typeName = property.getPrimaryType().toCanonical();
-                } catch (Exception ignored) {
-                    typeName = "<unknown>";
-                }
-                System.out.println(
-                        "[ATSAssist][IFTTT-DEBUG] property "
-                                + clazz.getSimpleName()
-                                + "."
-                                + property.getName()
-                                + " type="
-                                + typeName
-                                + " getter="
-                                + property.hasGetter()
-                                + " setter="
-                                + property.hasSetter()
-                                + " field="
-                                + property.hasField());
-            }
-        } catch (Exception e) {
-            System.out.println("[ATSAssist][IFTTT-DEBUG] debugClassInfo failed for " + clazz.getName() + ": " + e.getMessage());
-            e.printStackTrace();
-        }
     }
 
     private static byte[] convertClass(IFTTTContainer ifcb) {

--- a/src/main/java/jp/kaiz/atsassistmod/ifttt/IFTTTUtil.java
+++ b/src/main/java/jp/kaiz/atsassistmod/ifttt/IFTTTUtil.java
@@ -16,12 +16,9 @@ public class IFTTTUtil {
 
     public static byte[] convertClassSafe(IFTTTContainer ifcb) {
         try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ObjectOutputStream oos = new ObjectOutputStream(baos);
-            oos.writeObject(ifcb);
-            oos.flush();
-            return baos.toByteArray();
-        } catch (IOException e) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.writeValueAsBytes(ifcb);
+        } catch (JsonProcessingException e) {
             e.printStackTrace();
         }
         return null;
@@ -29,9 +26,9 @@ public class IFTTTUtil {
 
     public static IFTTTContainer convertClassSafe(byte[] bytes) {
         try {
-            ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes));
-            return (IFTTTContainer) ois.readObject();
-        } catch (IOException | ClassNotFoundException e) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(bytes, IFTTTContainer.class);
+        } catch (IOException e) {
             e.printStackTrace();
         }
         return null;

--- a/src/main/java/jp/kaiz/atsassistmod/ifttt/IFTTTUtil.java
+++ b/src/main/java/jp/kaiz/atsassistmod/ifttt/IFTTTUtil.java
@@ -1,34 +1,30 @@
 package jp.kaiz.atsassistmod.ifttt;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 public class IFTTTUtil {
     private final static Gson GSON = new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
-    private static final ObjectMapper IFTTT_MAPPER = createIFTTTMapper();
-
-    private static ObjectMapper createIFTTTMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
-        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        return mapper;
-    }
 
     public static byte[] convertClassSafe(IFTTTContainer ifcb) {
         try {
-            return IFTTT_MAPPER.writeValueAsBytes(ifcb);
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.writeValueAsBytes(ifcb);
         } catch (JsonProcessingException e) {
             e.printStackTrace();
         }
@@ -36,12 +32,85 @@ public class IFTTTUtil {
     }
 
     public static IFTTTContainer convertClassSafe(byte[] bytes) {
+        ObjectMapper objectMapper = new ObjectMapper();
         try {
-            return IFTTT_MAPPER.readValue(bytes, IFTTTContainer.class);
+            return objectMapper.readValue(bytes, IFTTTContainer.class);
         } catch (IOException e) {
+            debugDeserializeFailure(objectMapper, bytes, e);
             e.printStackTrace();
         }
         return null;
+    }
+
+    private static void debugDeserializeFailure(ObjectMapper objectMapper, byte[] bytes, IOException exception) {
+        System.out.println("[ATSAssist][IFTTT-DEBUG] deserialize failed: " + exception.getClass().getName() + " / " + exception.getMessage());
+        if (exception instanceof JsonMappingException) {
+            JsonMappingException jsonMappingException = (JsonMappingException) exception;
+            System.out.println("[ATSAssist][IFTTT-DEBUG] path: " + jsonMappingException.getPathReference());
+        }
+        System.out.println("[ATSAssist][IFTTT-DEBUG] payload bytes: " + (bytes == null ? "null" : bytes.length));
+        if (bytes == null) {
+            return;
+        }
+
+        try {
+            String json = new String(bytes, StandardCharsets.UTF_8);
+            System.out.println("[ATSAssist][IFTTT-DEBUG] payload json: " + json);
+            JsonNode root = objectMapper.readTree(bytes);
+            if (root != null && root.has("@class")) {
+                String className = root.get("@class").asText();
+                System.out.println("[ATSAssist][IFTTT-DEBUG] @class: " + className);
+                try {
+                    Class<?> targetClass = Class.forName(className);
+                    debugClassInfo(objectMapper, targetClass);
+                } catch (ClassNotFoundException classNotFoundException) {
+                    System.out.println("[ATSAssist][IFTTT-DEBUG] @class not found: " + classNotFoundException.getMessage());
+                }
+            }
+        } catch (IOException parseException) {
+            System.out.println("[ATSAssist][IFTTT-DEBUG] could not parse payload as json: " + parseException.getMessage());
+        }
+
+        debugClassInfo(objectMapper, IFTTTContainer.class);
+    }
+
+    private static void debugClassInfo(ObjectMapper objectMapper, Class<?> clazz) {
+        try {
+            JavaType javaType = objectMapper.getTypeFactory().constructType(clazz);
+            AtomicReference<Throwable> cause = new AtomicReference<>();
+            boolean canDeserialize = objectMapper.canDeserialize(javaType, cause);
+            System.out.println("[ATSAssist][IFTTT-DEBUG] canDeserialize " + clazz.getName() + ": " + canDeserialize);
+            if (cause.get() != null) {
+                System.out.println("[ATSAssist][IFTTT-DEBUG] canDeserialize cause for " + clazz.getName() + ":");
+                cause.get().printStackTrace();
+            }
+
+            BeanDescription description = objectMapper.getDeserializationConfig().introspect(javaType);
+            for (BeanPropertyDefinition property : description.findProperties()) {
+                String typeName;
+                try {
+                    typeName = property.getPrimaryType().toCanonical();
+                } catch (Exception ignored) {
+                    typeName = "<unknown>";
+                }
+                System.out.println(
+                        "[ATSAssist][IFTTT-DEBUG] property "
+                                + clazz.getSimpleName()
+                                + "."
+                                + property.getName()
+                                + " type="
+                                + typeName
+                                + " getter="
+                                + property.hasGetter()
+                                + " setter="
+                                + property.hasSetter()
+                                + " field="
+                                + property.hasField());
+            }
+        } catch (Exception e) {
+            System.out.println("[ATSAssist][IFTTT-DEBUG] debugClassInfo failed for " + clazz.getName() + ": " + e.getMessage());
+            e.printStackTrace();
+        }
     }
 
     private static byte[] convertClass(IFTTTContainer ifcb) {


### PR DESCRIPTION
### 概要
特定環境で IF/THEN の保存内容が反映されない不具合を修正しました。  
原因は `IFTTTUtil` の Jackson 逆シリアライズで、GUI由来メソッドまで復元対象となり、他Mod同居時の型解決エラーに繋がっていた可能性が高いです。

### 変更内容
- `IFTTTUtil` の `ObjectMapper` を IFTTT向け設定に固定
- 逆シリアライズ対象をフィールドのみに限定
- 不要プロパティで失敗しないよう設定を調整

### 備考
- Custom NPCs / Essential など他Mod同居環境でも、IF/THEN の保存内容が反映されることを確認しています。
- もし見落としや懸念点があれば、ご指摘いただけると助かります。